### PR TITLE
Update to protobuf-elixir 0.7.1 and regenerate Elixir code

### DIFF
--- a/lib/google_protos/any.pb.ex
+++ b/lib/google_protos/any.pb.ex
@@ -4,7 +4,7 @@ defmodule Google.Protobuf.Any do
 
   @type t :: %__MODULE__{
           type_url: String.t(),
-          value: String.t()
+          value: binary
         }
   defstruct [:type_url, :value]
 

--- a/lib/google_protos/empty.pb.ex
+++ b/lib/google_protos/empty.pb.ex
@@ -2,5 +2,6 @@ defmodule Google.Protobuf.Empty do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
+  @type t :: %__MODULE__{}
   defstruct []
 end

--- a/lib/google_protos/struct.pb.ex
+++ b/lib/google_protos/struct.pb.ex
@@ -1,13 +1,10 @@
-defmodule Google.Protobuf.Struct do
+defmodule Google.Protobuf.NullValue do
   @moduledoc false
-  use Protobuf, syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3
 
-  @type t :: %__MODULE__{
-          fields: %{String.t() => Google.Protobuf.Value.t()}
-        }
-  defstruct [:fields]
+  @type t :: integer | :NULL_VALUE
 
-  field :fields, 1, repeated: true, type: Google.Protobuf.Struct.FieldsEntry, map: true
+  field :NULL_VALUE, 0
 end
 
 defmodule Google.Protobuf.Struct.FieldsEntry do
@@ -16,12 +13,24 @@ defmodule Google.Protobuf.Struct.FieldsEntry do
 
   @type t :: %__MODULE__{
           key: String.t(),
-          value: Google.Protobuf.Value.t()
+          value: Google.Protobuf.Value.t() | nil
         }
   defstruct [:key, :value]
 
   field :key, 1, type: :string
   field :value, 2, type: Google.Protobuf.Value
+end
+
+defmodule Google.Protobuf.Struct do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          fields: %{String.t() => Google.Protobuf.Value.t() | nil}
+        }
+  defstruct [:fields]
+
+  field :fields, 1, repeated: true, type: Google.Protobuf.Struct.FieldsEntry, map: true
 end
 
 defmodule Google.Protobuf.Value do
@@ -52,11 +61,4 @@ defmodule Google.Protobuf.ListValue do
   defstruct [:values]
 
   field :values, 1, repeated: true, type: Google.Protobuf.Value
-end
-
-defmodule Google.Protobuf.NullValue do
-  @moduledoc false
-  use Protobuf, enum: true, syntax: :proto3
-
-  field :NULL_VALUE, 0
 end

--- a/lib/google_protos/wrappers.pb.ex
+++ b/lib/google_protos/wrappers.pb.ex
@@ -3,7 +3,7 @@ defmodule Google.Protobuf.DoubleValue do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-          value: float
+          value: float | :infinity | :negative_infinity | :nan
         }
   defstruct [:value]
 
@@ -15,7 +15,7 @@ defmodule Google.Protobuf.FloatValue do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-          value: float
+          value: float | :infinity | :negative_infinity | :nan
         }
   defstruct [:value]
 
@@ -99,7 +99,7 @@ defmodule Google.Protobuf.BytesValue do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-          value: String.t()
+          value: binary
         }
   defstruct [:value]
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule GoogleProtos.MixProject do
 
   defp deps do
     [
-      {:protobuf, "~> 0.5"},
+      {:protobuf, "~> 0.7"},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "protobuf": {:hex, :protobuf, "0.5.2", "c1338db827614cbe03a479ac9ef22bd8f3d0ff8a6bb44db5f63037688cd7806c", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "33d7b70d87d45ed899180fb0413fb77c7c48843188516e15747e00fdecf572b6"},
+  "protobuf": {:hex, :protobuf, "0.7.1", "7d1b9f7d9ecb32eccd96b0c58572de4d1c09e9e3bc414e4cb15c2dce7013f195", [:mix], [], "hexpm", "6eff7a5287963719521c82e5d5b4583fd1d7cdd89ad129f0ea7d503a50a4d13f"},
 }


### PR DESCRIPTION
This PR simply bumps up the version of `protobuf-elixir` to the latest stable version 0.7.1 and includes the generated Elixir code after rerunning the generation script.