### PR TITLE
Add `FieldMask` and regenerate Elixir code

### DIFF
--- a/generate_google_protos.sh
+++ b/generate_google_protos.sh
@@ -4,6 +4,7 @@ PROTOS=("
     protobuf/src/google/protobuf/any.proto
     protobuf/src/google/protobuf/duration.proto
     protobuf/src/google/protobuf/empty.proto
+    protobuf/src/google/protobuf/field_mask.proto
     protobuf/src/google/protobuf/struct.proto
     protobuf/src/google/protobuf/timestamp.proto
     protobuf/src/google/protobuf/wrappers.proto

--- a/lib/google_protos/any.pb.ex
+++ b/lib/google_protos/any.pb.ex
@@ -6,11 +6,8 @@ defmodule Google.Protobuf.Any do
           type_url: String.t(),
           value: binary
         }
-
   defstruct [:type_url, :value]
 
-  field :type_url, 1, type: :string, json_name: "typeUrl"
+  field :type_url, 1, type: :string
   field :value, 2, type: :bytes
-
-  def transform_module(), do: nil
 end

--- a/lib/google_protos/duration.pb.ex
+++ b/lib/google_protos/duration.pb.ex
@@ -6,11 +6,8 @@ defmodule Google.Protobuf.Duration do
           seconds: integer,
           nanos: integer
         }
-
   defstruct [:seconds, :nanos]
 
   field :seconds, 1, type: :int64
   field :nanos, 2, type: :int32
-
-  def transform_module(), do: nil
 end

--- a/lib/google_protos/empty.pb.ex
+++ b/lib/google_protos/empty.pb.ex
@@ -1,9 +1,7 @@
 defmodule Google.Protobuf.Empty do
   @moduledoc false
   use Protobuf, syntax: :proto3
+
   @type t :: %__MODULE__{}
-
   defstruct []
-
-  def transform_module(), do: nil
 end

--- a/lib/google_protos/field_mask.pb.ex
+++ b/lib/google_protos/field_mask.pb.ex
@@ -1,0 +1,11 @@
+defmodule Google.Protobuf.FieldMask do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          paths: [String.t()]
+        }
+  defstruct [:paths]
+
+  field :paths, 1, repeated: true, type: :string
+end

--- a/lib/google_protos/struct.pb.ex
+++ b/lib/google_protos/struct.pb.ex
@@ -1,6 +1,7 @@
 defmodule Google.Protobuf.NullValue do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto3
+
   @type t :: integer | :NULL_VALUE
 
   field :NULL_VALUE, 0
@@ -14,13 +15,10 @@ defmodule Google.Protobuf.Struct.FieldsEntry do
           key: String.t(),
           value: Google.Protobuf.Value.t() | nil
         }
-
   defstruct [:key, :value]
 
   field :key, 1, type: :string
   field :value, 2, type: Google.Protobuf.Value
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Struct do
@@ -30,12 +28,9 @@ defmodule Google.Protobuf.Struct do
   @type t :: %__MODULE__{
           fields: %{String.t() => Google.Protobuf.Value.t() | nil}
         }
-
   defstruct [:fields]
 
   field :fields, 1, repeated: true, type: Google.Protobuf.Struct.FieldsEntry, map: true
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Value do
@@ -43,32 +38,17 @@ defmodule Google.Protobuf.Value do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-          kind:
-            {:null_value, Google.Protobuf.NullValue.t()}
-            | {:number_value, float | :infinity | :negative_infinity | :nan}
-            | {:string_value, String.t()}
-            | {:bool_value, boolean}
-            | {:struct_value, Google.Protobuf.Struct.t() | nil}
-            | {:list_value, Google.Protobuf.ListValue.t() | nil}
+          kind: {atom, any}
         }
-
   defstruct [:kind]
 
   oneof :kind, 0
-
-  field :null_value, 1,
-    type: Google.Protobuf.NullValue,
-    enum: true,
-    json_name: "nullValue",
-    oneof: 0
-
-  field :number_value, 2, type: :double, json_name: "numberValue", oneof: 0
-  field :string_value, 3, type: :string, json_name: "stringValue", oneof: 0
-  field :bool_value, 4, type: :bool, json_name: "boolValue", oneof: 0
-  field :struct_value, 5, type: Google.Protobuf.Struct, json_name: "structValue", oneof: 0
-  field :list_value, 6, type: Google.Protobuf.ListValue, json_name: "listValue", oneof: 0
-
-  def transform_module(), do: nil
+  field :null_value, 1, type: Google.Protobuf.NullValue, enum: true, oneof: 0
+  field :number_value, 2, type: :double, oneof: 0
+  field :string_value, 3, type: :string, oneof: 0
+  field :bool_value, 4, type: :bool, oneof: 0
+  field :struct_value, 5, type: Google.Protobuf.Struct, oneof: 0
+  field :list_value, 6, type: Google.Protobuf.ListValue, oneof: 0
 end
 
 defmodule Google.Protobuf.ListValue do
@@ -78,10 +58,7 @@ defmodule Google.Protobuf.ListValue do
   @type t :: %__MODULE__{
           values: [Google.Protobuf.Value.t()]
         }
-
   defstruct [:values]
 
   field :values, 1, repeated: true, type: Google.Protobuf.Value
-
-  def transform_module(), do: nil
 end

--- a/lib/google_protos/timestamp.pb.ex
+++ b/lib/google_protos/timestamp.pb.ex
@@ -6,11 +6,8 @@ defmodule Google.Protobuf.Timestamp do
           seconds: integer,
           nanos: integer
         }
-
   defstruct [:seconds, :nanos]
 
   field :seconds, 1, type: :int64
   field :nanos, 2, type: :int32
-
-  def transform_module(), do: nil
 end

--- a/lib/google_protos/wrappers.pb.ex
+++ b/lib/google_protos/wrappers.pb.ex
@@ -5,12 +5,9 @@ defmodule Google.Protobuf.DoubleValue do
   @type t :: %__MODULE__{
           value: float | :infinity | :negative_infinity | :nan
         }
-
   defstruct [:value]
 
   field :value, 1, type: :double
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.FloatValue do
@@ -20,12 +17,9 @@ defmodule Google.Protobuf.FloatValue do
   @type t :: %__MODULE__{
           value: float | :infinity | :negative_infinity | :nan
         }
-
   defstruct [:value]
 
   field :value, 1, type: :float
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Int64Value do
@@ -35,12 +29,9 @@ defmodule Google.Protobuf.Int64Value do
   @type t :: %__MODULE__{
           value: integer
         }
-
   defstruct [:value]
 
   field :value, 1, type: :int64
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.UInt64Value do
@@ -50,12 +41,9 @@ defmodule Google.Protobuf.UInt64Value do
   @type t :: %__MODULE__{
           value: non_neg_integer
         }
-
   defstruct [:value]
 
   field :value, 1, type: :uint64
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Int32Value do
@@ -65,12 +53,9 @@ defmodule Google.Protobuf.Int32Value do
   @type t :: %__MODULE__{
           value: integer
         }
-
   defstruct [:value]
 
   field :value, 1, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.UInt32Value do
@@ -80,12 +65,9 @@ defmodule Google.Protobuf.UInt32Value do
   @type t :: %__MODULE__{
           value: non_neg_integer
         }
-
   defstruct [:value]
 
   field :value, 1, type: :uint32
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.BoolValue do
@@ -95,12 +77,9 @@ defmodule Google.Protobuf.BoolValue do
   @type t :: %__MODULE__{
           value: boolean
         }
-
   defstruct [:value]
 
   field :value, 1, type: :bool
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.StringValue do
@@ -110,12 +89,9 @@ defmodule Google.Protobuf.StringValue do
   @type t :: %__MODULE__{
           value: String.t()
         }
-
   defstruct [:value]
 
   field :value, 1, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.BytesValue do
@@ -125,10 +101,7 @@ defmodule Google.Protobuf.BytesValue do
   @type t :: %__MODULE__{
           value: binary
         }
-
   defstruct [:value]
 
   field :value, 1, type: :bytes
-
-  def transform_module(), do: nil
 end


### PR DESCRIPTION
This PR adds `FieldMask` to the `PROTOS` array in `generate_google_protos.sh`. It also includes the result of running the script to generate the Elixir code to make `field_mask` available.


--- 
_Comment/question_: I'm noticing that as well as adding the new `field_mask.pb.ex`, after running the codegen script `transform_module` functions have been removed, as well as the `jsonName` properties on some of the fields.

Have I missed something in running the script, or might it need to be updated to include these fields?

This was generated with `protoc-gen-elixir 0.7.1`, `protoc libprotoc 3.17.3` on `Elixir 1.10.3`.