### PR TITLE
publish v0.4.0 supporting grpc-reflection

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule GoogleProtos.MixProject do
     [
       app: :google_protos,
       name: "Google Protos",
-      version: "0.4.0-rc1",
+      version: "0.4.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This PR follows #22, which published v0.4.0-rc1, aiming to officially release v0.4.0 to support grpc-reflection.